### PR TITLE
Adds Diode CLI as systemd service

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -131,7 +131,7 @@ Description=Diode blockchain network client
 
 [Service]
 Type=simple
-ExecStart=/root/opt/diode/diode -logfilepath=/root/.config/diode/debug.log -logdatetime=true -debug=true publish -public 80:80
+ExecStart=/root/opt/diode/diode publish -public 80:80
 Restart=always
 RuntimeMaxSec=14400
 ExecStartPre=/bin/sleep 60

--- a/setup.sh
+++ b/setup.sh
@@ -121,9 +121,33 @@ wp theme activate --allow-root --path="/srv/www/wordpress" disciple-tools-theme
 chown -Rf www-data.www-data /srv/www
 #cp /etc/skel/.bashrc /root
 
-#start diode server
-echo "http://${diode_address}.diode.link"
-diode publish -public 80:80 &
+#start diode CLI
+echo "Starting http://${diode_address}.diode.link"
+
+#Configure systemd for diode
+echo "# Can be put into /etc/systemd/system/
+[Unit]
+Description=Diode blockchain network client
+
+[Service]
+Type=simple
+ExecStart=/root/opt/diode/diode -logfilepath=/root/.config/diode/debug.log -logdatetime=true -debug=true publish -public 80:80
+Restart=always
+RuntimeMaxSec=14400
+ExecStartPre=/bin/sleep 60
+User=root
+
+[Install]
+WantedBy=multi-user.target" > /etc/systemd/system/diode.service
+
+#Enable diode
+systemctl enable diode
+echo "Starting Diode - 60 second delay..."
+systemctl start diode
+systemctl status diode
+
+echo "Done setting up the Diode CLI - it is now persistent on this system"
+echo "You can type 'systemctl status diode' to get status on the Diode CLI in the future"
 
 #display login instructions
 echo "wordpress url is http://${diode_address}.diode.link"


### PR DESCRIPTION
Currently set to max run-time of 14400 and uses a 60 second delay as a brain-dead startup delay to allow network to connect.  Should increase max run time and make delay to be wait-for-network instead in future once stability / longevity verified.